### PR TITLE
fix crash related to null sections on kade format

### DIFF
--- a/src/moonchart/formats/fnf/FNFKade.hx
+++ b/src/moonchart/formats/fnf/FNFKade.hx
@@ -125,9 +125,11 @@ class FNFKade extends BasicJsonFormat<{song:FNFKadeFormat}, FNFKadeMeta>
 
 		for (i in 0...fnfData.notes.length)
 		{
-			var fnfSection = fnfData.notes[i];
 			var basicSection = measures[i];
+			if(basicSection == null)
+				continue;
 
+			var fnfSection = fnfData.notes[i];
 			var kadeNotes:Array<FNFKadeNote> = [];
 
 			for (note in fnfSection.sectionNotes)


### PR DESCRIPTION
why can this happen for specific charts???