### PR TITLE
Fix stepmania offset casting error in hashlink

### DIFF
--- a/src/moonchart/parsers/StepManiaParser.hx
+++ b/src/moonchart/parsers/StepManiaParser.hx
@@ -230,6 +230,8 @@ class BasicStepManiaParser<T:StepManiaFormat> extends BasicParser<T>
 						duration: Std.parseFloat(workable_data[1])
 					});
 				}
+			case 'OFFSET':
+				formatted.OFFSET = Std.parseFloat(value);
 			default:
 				if (Reflect.hasField(formatted, title))
 					Reflect.setField(formatted, title, value);


### PR DESCRIPTION
`OFFSET` is a string so referencing it causes a casting error in HashLink due to it's strictness nature
Implemented it in a way that doesn't cause any breaking changes, but ideally `OFFSET` itself should be declared as a string