### PR TITLE
BPM Resyncing Adjustment

### DIFF
--- a/src/moonchart/formats/StepMania.hx
+++ b/src/moonchart/formats/StepMania.hx
@@ -324,11 +324,11 @@ abstract class StepManiaBasic<T:StepManiaFormat> extends BasicFormat<T, {}>
 					var nextBeat = bpmChange.beat;
 					var remainingBeats = nextBeat - beat;
 					time += remainingBeats * Timing.crochet(bpm);
+					time -= remainingBeats * Timing.crochet(bpmChange.bpm);
 
 					// Update the rest of the crap and snap to the new beat
 					bpm = bpmChange.bpm;
 					stepCrochet = getStepCrochet(steps);
-					beat = nextBeat;
 					bpmIndex++;
 				}
 


### PR DESCRIPTION
Very simple but seems reasonable.

Assuming you're doing this incase the bpm change in in the middle of two rows, then it makes sense to resync it with the proper bpm.

Also, with that there should be no need to set the beat to the change's beat, we _want_ this to be in the correct row, not suddenly jump back which perma desyncs the beat if the scenario given comes true.