### PR TITLE
Fix default note type parsing in FNFCodename

### DIFF
--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -235,6 +235,13 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 
 	public function resolveNoteType(type:Int)
 	{
+		if (data.noteTypes[0] != "")
+		{
+			// make sure the default note type is added here otherwise
+			// 0 will link to something like "Alt Animation" or any other non-default note type
+			// 0 in codename is always the default note type
+			data.noteTypes.insert(0, "");
+		}
 		var noteType = data.noteTypes[type] ?? "";
 		return noteTypeResolver.toBasic(noteType);
 	}


### PR DESCRIPTION
Ensures that the default note type is parsed correctly when converting Codename charts

What would happen was instead of 0 being treated as default, it would be treated as the first note type in the note types list, which means most notes could be Alt Animation notes or something like that when that wasn't intended