### PR TITLE
Touch up Codename camera event handling

### DIFF
--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -210,20 +210,10 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 				}
 			case BasicFNFEvent.ZOOM_CAMERA:
 				var data:BasicFNFZoomCameraEvent = event.data;
-
-				var ease:String = data.ease;
-				var easeDir:String = "";
-
-				// TOOD: is there a better way to do this?
-				var easeCheck:String = ease.toLowerCase();
-				if(easeCheck.endsWith("in")) easeDir = "In";
-				else if(easeCheck.endsWith("inout")) easeDir = "InOut";
-				else if(easeCheck.endsWith("out")) easeDir = "Out";
-
 				return {
 					time: event.time,
 					name: "Camera Zoom",
-					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, ease, easeDir] // TODO: add missing params
+					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, data.ease] // TODO: add missing params
 				}
 			case BasicFNFEvent.SET_CAMERA_BOP:
 				var data:BasicFNFSetCameraBopEvent = event.data;

--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -361,7 +361,9 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 	    switch(event.name) {
 			case FNFCodename.CODENAME_CAM_POSITION:
 			    var data:BasicFNFPositionCameraEvent = {
-                x: event.params[0],
+					char: -1,
+
+                    x: event.params[0],
 				    y: event.params[1],
 
 					ease: (event.params[2]) ? ((event.params[4] ?? "linear") + (event.params[5] ?? "")) : "CLASSIC",

--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -210,10 +210,20 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 				}
 			case BasicFNFEvent.ZOOM_CAMERA:
 				var data:BasicFNFZoomCameraEvent = event.data;
+
+				var ease:String = data.ease;
+				var easeDir:String = "";
+
+				// TOOD: is there a better way to do this?
+				var easeCheck:String = ease.toLowerCase();
+				if(easeCheck.endsWith("in")) easeDir = "In";
+				else if(easeCheck.endsWith("inout")) easeDir = "InOut";
+				else if(easeCheck.endsWith("out")) easeDir = "Out";
+
 				return {
 					time: event.time,
 					name: "Camera Zoom",
-					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration] // TODO: add missing params
+					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, ease, easeDir] // TODO: add missing params
 				}
 			case BasicFNFEvent.SET_CAMERA_BOP:
 				var data:BasicFNFSetCameraBopEvent = event.data;

--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -8,6 +8,8 @@ import moonchart.formats.BasicFormat;
 import moonchart.formats.fnf.FNFGlobal;
 import moonchart.formats.fnf.legacy.FNFLegacy;
 
+using StringTools;
+
 enum abstract FNFCodenameNoteType(String) from String to String
 {
 	var CODENAME_ALT_ANIM = "Alt Anim Note";
@@ -209,42 +211,39 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 					name: "Play Animation",
 					params: [target, data.anim, data.force]
 				}
+
 			case BasicFNFEvent.ZOOM_CAMERA:
 				var data:BasicFNFZoomCameraEvent = event.data;
-
-				var ease:String = data.ease;
-				var easeDir:String = "";
-
-				// TOOD: is there a better way to do this?
-				var easeCheck:String = ease.toLowerCase();
-				if(easeCheck.endsWith("in")) easeDir = "In";
-				else if(easeCheck.endsWith("inout")) easeDir = "InOut";
-				else if(easeCheck.endsWith("out")) easeDir = "Out";
-
-				ease = ease.substr(0, ease.length - easeDir.length);
+				var easing = resolveEase(data.ease);
 				return {
 					time: event.time,
 					name: "Camera Zoom",
-					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, ease, easeDir] // TODO: add missing params
+					params: [
+						data.ease != "INSTANT",
+						data.zoom,
+						"camGame",
+						data.duration,
+						easing[0],
+						easing[1]
+					] // TODO: add missing params
 				}
 
 			case BasicFNFEvent.POSITION_CAMERA:
-			    var data:BasicFNFPositionCameraEvent = event.data;
+				var data:BasicFNFPositionCameraEvent = event.data;
+				var easing = resolveEase(data.ease);
 
-				var ease:String = data.ease;
-				var easeDir:String = "";
-
-				// TOOD: is there a better way to do this?
-				var easeCheck:String = ease.toLowerCase();
-				if(easeCheck.endsWith("in")) easeDir = "In";
-				else if(easeCheck.endsWith("inout")) easeDir = "InOut";
-				else if(easeCheck.endsWith("out")) easeDir = "Out";
-
-				ease = ease.substr(0, ease.length - easeDir.length);
 				return {
-				    time: event.time,
+					time: event.time,
 					name: "Camera Position",
-					params: [data.x, data.y, data.ease != "INSTANT", data.duration, ease, easeDir, data.isOffset]
+					params: [
+						data.x,
+						data.y,
+						data.ease != "INSTANT",
+						data.duration,
+						easing[0],
+						easing[1],
+						data.isOffset
+					]
 				}
 
 			case BasicFNFEvent.SET_CAMERA_BOP:
@@ -277,30 +276,34 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 			default: 2;
 		}
 
-		var ease:String = event.data.ease;
-    	var easeDir:String = "";
-
-    	// TOOD: is there a better way to do this?
-    	var easeCheck:String = ease.toLowerCase();
-    	if(easeCheck.endsWith("in")) easeDir = "In";
-    	else if(easeCheck.endsWith("inout")) easeDir = "InOut";
-    	else if(easeCheck.endsWith("out")) easeDir = "Out";
-
-    	ease = ease.substr(0, ease.length - easeDir.length);
-
-    	final duration:Int = event.data.duration ?? 4;
-    	final doLerp:Bool = ease != "INSTANT";
+		final easing:Array<String> = resolveEase(event.data.ease);
+		final duration:Int = event.data.duration ?? 4;
+		final doLerp:Bool = easing[0] != "INSTANT";
 
 		// character(int), lerp(bool), duration(int), ease(string), easeSuffix(?string)
 
-		// TODO: add eases
 		// TODO: add "Camera Position" event
 
 		return {
 			time: event.time,
 			name: CODENAME_CAM_MOVEMENT,
-			params: [char, doLerp, duration, ease, easeDir]
+			params: [char, doLerp, duration, easing[0], easing[1]]
 		}
+	}
+
+	function resolveEase(ease:String):Array<String>
+	{
+		var easeDir:String = "";
+
+		var easeCheck:String = ease.toLowerCase();
+		if (easeCheck.endsWith("in"))
+			easeDir = "In";
+		else if (easeCheck.endsWith("inout"))
+			easeDir = "InOut";
+		else if (easeCheck.endsWith("out"))
+			easeDir = "Out";
+
+		return [ease.substr(0, ease.length - easeDir.length), easeDir];
 	}
 
 	inline function formatSongName(name:String):String
@@ -357,27 +360,25 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 
 	function encodeCodenameEvent(event:FNFCodenameEvent):BasicEvent
 	{
-	    var time:Float = event.time;
-	    switch(event.name) {
+		var time:Float = event.time;
+		switch (event.name)
+		{
 			case FNFCodename.CODENAME_CAM_POSITION:
-			    var data:BasicFNFPositionCameraEvent = {
+				var data:BasicFNFPositionCameraEvent = {
 					char: -1,
-
-                    x: event.params[0],
-				    y: event.params[1],
-
+					x: event.params[0],
+					y: event.params[1],
 					ease: (event.params[2]) ? ((event.params[4] ?? "linear") + (event.params[5] ?? "")) : "CLASSIC",
 					duration: (event.params[2]) ? event.params[3] : 0,
-
 					isOffset: event.params[6]
 				};
-			    return {
+				return {
 					time: time,
 					name: BasicFNFEvent.POSITION_CAMERA,
 					data: data
 				}
 		}
-	    return Util.makeArrayEvent(time, event.name, event.params);
+		return Util.makeArrayEvent(time, event.name, event.params);
 	}
 
 	override function getEvents():Array<BasicEvent>

--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -210,10 +210,21 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 				}
 			case BasicFNFEvent.ZOOM_CAMERA:
 				var data:BasicFNFZoomCameraEvent = event.data;
+
+				var ease:String = data.ease;
+				var easeDir:String = "";
+
+				// TOOD: is there a better way to do this?
+				var easeCheck:String = ease.toLowerCase();
+				if(easeCheck.endsWith("in")) easeDir = "In";
+				else if(easeCheck.endsWith("inout")) easeDir = "InOut";
+				else if(easeCheck.endsWith("out")) easeDir = "Out";
+
+				ease = ease.substr(0, ease.length - easeDir.length);
 				return {
 					time: event.time,
 					name: "Camera Zoom",
-					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, data.ease] // TODO: add missing params
+					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, ease, easeDir] // TODO: add missing params
 				}
 			case BasicFNFEvent.SET_CAMERA_BOP:
 				var data:BasicFNFSetCameraBopEvent = event.data;

--- a/src/moonchart/formats/fnf/FNFCodename.hx
+++ b/src/moonchart/formats/fnf/FNFCodename.hx
@@ -41,6 +41,7 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 	public static inline var CODENAME_BPM_CHANGE:String = "BPM Change";
 	public static inline var CODENAME_TIME_SIG_CHANGE:String = "Time Signature Change";
 	public static inline var CODENAME_CAM_MOVEMENT:String = "Camera Movement";
+	public static inline var CODENAME_CAM_POSITION:String = "Camera Position";
 
 	public var noteTypeResolver(default, null):FNFNoteTypeResolver;
 
@@ -226,6 +227,26 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 					name: "Camera Zoom",
 					params: [data.ease != "INSTANT", data.zoom, "camGame", data.duration, ease, easeDir] // TODO: add missing params
 				}
+
+			case BasicFNFEvent.POSITION_CAMERA:
+			    var data:BasicFNFPositionCameraEvent = event.data;
+
+				var ease:String = data.ease;
+				var easeDir:String = "";
+
+				// TOOD: is there a better way to do this?
+				var easeCheck:String = ease.toLowerCase();
+				if(easeCheck.endsWith("in")) easeDir = "In";
+				else if(easeCheck.endsWith("inout")) easeDir = "InOut";
+				else if(easeCheck.endsWith("out")) easeDir = "Out";
+
+				ease = ease.substr(0, ease.length - easeDir.length);
+				return {
+				    time: event.time,
+					name: "Camera Position",
+					params: [data.x, data.y, data.ease != "INSTANT", data.duration, ease, easeDir, data.isOffset]
+				}
+
 			case BasicFNFEvent.SET_CAMERA_BOP:
 				var data:BasicFNFSetCameraBopEvent = event.data;
 				return {
@@ -256,8 +277,19 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 			default: 2;
 		}
 
-		final duration:Int = event.data.duration ?? 4;
-		final doLerp:Bool = event.data.ease != "INSTANT";
+		var ease:String = event.data.ease;
+    	var easeDir:String = "";
+
+    	// TOOD: is there a better way to do this?
+    	var easeCheck:String = ease.toLowerCase();
+    	if(easeCheck.endsWith("in")) easeDir = "In";
+    	else if(easeCheck.endsWith("inout")) easeDir = "InOut";
+    	else if(easeCheck.endsWith("out")) easeDir = "Out";
+
+    	ease = ease.substr(0, ease.length - easeDir.length);
+
+    	final duration:Int = event.data.duration ?? 4;
+    	final doLerp:Bool = ease != "INSTANT";
 
 		// character(int), lerp(bool), duration(int), ease(string), easeSuffix(?string)
 
@@ -267,7 +299,7 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 		return {
 			time: event.time,
 			name: CODENAME_CAM_MOVEMENT,
-			params: [char, doLerp, duration]
+			params: [char, doLerp, duration, ease, easeDir]
 		}
 	}
 
@@ -323,6 +355,29 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 		return noteTypeResolver.toBasic(noteType);
 	}
 
+	function encodeCodenameEvent(event:FNFCodenameEvent):BasicEvent
+	{
+	    var time:Float = event.time;
+	    switch(event.name) {
+			case FNFCodename.CODENAME_CAM_POSITION:
+			    var data:BasicFNFPositionCameraEvent = {
+                x: event.params[0],
+				    y: event.params[1],
+
+					ease: (event.params[2]) ? ((event.params[4] ?? "linear") + (event.params[5] ?? "")) : "CLASSIC",
+					duration: (event.params[2]) ? event.params[3] : 0,
+
+					isOffset: event.params[6]
+				};
+			    return {
+					time: time,
+					name: BasicFNFEvent.POSITION_CAMERA,
+					data: data
+				}
+		}
+	    return Util.makeArrayEvent(time, event.name, event.params);
+	}
+
 	override function getEvents():Array<BasicEvent>
 	{
 		var events:Array<BasicEvent> = [];
@@ -330,7 +385,7 @@ class FNFCodename extends BasicJsonFormat<FNFCodenameFormat, FNFCodenameMeta>
 		for (event in data.events)
 		{
 			if (event.name != CODENAME_BPM_CHANGE && event.name != CODENAME_TIME_SIG_CHANGE)
-				events.push(Util.makeArrayEvent(event.time, event.name, event.params));
+				events.push(encodeCodenameEvent(event));
 		}
 
 		// Set the default init cam movement

--- a/src/moonchart/formats/fnf/FNFGlobal.hx
+++ b/src/moonchart/formats/fnf/FNFGlobal.hx
@@ -67,6 +67,8 @@ typedef BasicFNFSetCameraBopEvent =
 
 typedef BasicFNFPositionCameraEvent =
 {
+    var char:Int;
+
     var x:Float;
     var y:Float;
 

--- a/src/moonchart/formats/fnf/FNFGlobal.hx
+++ b/src/moonchart/formats/fnf/FNFGlobal.hx
@@ -39,6 +39,7 @@ enum abstract BasicFNFEvent(String) from String to String
 {
 	var PLAY_ANIMATION;
 	var ZOOM_CAMERA;
+	var POSITION_CAMERA;
 	var SET_CAMERA_BOP;
 }
 
@@ -62,6 +63,17 @@ typedef BasicFNFSetCameraBopEvent =
 	var rate:Int;
 	var offset:Int;
 	var intensity:Float;
+}
+
+typedef BasicFNFPositionCameraEvent =
+{
+    var x:Float;
+    var y:Float;
+
+    var ease:String;
+    var duration:Float;
+
+    var isOffset:Bool;
 }
 
 /**

--- a/src/moonchart/formats/fnf/FNFGlobal.hx
+++ b/src/moonchart/formats/fnf/FNFGlobal.hx
@@ -67,15 +67,12 @@ typedef BasicFNFSetCameraBopEvent =
 
 typedef BasicFNFPositionCameraEvent =
 {
-    var char:Int;
-
-    var x:Float;
-    var y:Float;
-
-    var ease:String;
-    var duration:Float;
-
-    var isOffset:Bool;
+	var char:Int;
+	var x:Float;
+	var y:Float;
+	var ease:String;
+	var duration:Float;
+	var isOffset:Bool;
 }
 
 /**

--- a/src/moonchart/formats/fnf/FNFVSlice.hx
+++ b/src/moonchart/formats/fnf/FNFVSlice.hx
@@ -406,7 +406,7 @@ class FNFVSlice extends BasicJsonFormat<FNFVSliceFormat, FNFVSliceMeta>
 				final data:BasicFNFZoomCameraEvent = {
 					zoom: event.v.zoom ?? 1.0,
 					duration: event.v.duration ?? 4,
-					ease: null,
+					ease: (event.v.ease ?? "linear") + (event.v.easeDir ?? ""),
 					mode: "stage"
 				}
 				return {

--- a/src/moonchart/formats/fnf/FNFVSlice.hx
+++ b/src/moonchart/formats/fnf/FNFVSlice.hx
@@ -4,6 +4,7 @@ import moonchart.backend.FormatData;
 import moonchart.backend.Timing;
 import moonchart.backend.Util;
 import moonchart.formats.BasicFormat;
+import moonchart.formats.fnf.FNFGlobal.BasicFNFPositionCameraEvent;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFCamFocusData;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFEvent;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFNoteType;
@@ -394,6 +395,8 @@ class FNFVSlice extends BasicJsonFormat<FNFVSliceFormat, FNFVSliceMeta>
 			case FNFVSlice.VSLICE_FOCUS_EVENT:
 				if(!(event.v is Int) && (event.v.x != null || event.v.y != null || event.v.duration != null || event.v.ease != null || event.v.easeDir != null)) {
     				final data:BasicFNFPositionCameraEvent = {
+                        char: event.v.char ?? -1,
+
         				x: event.v.x,
         				y: event.v.y,
 

--- a/src/moonchart/formats/fnf/FNFVSlice.hx
+++ b/src/moonchart/formats/fnf/FNFVSlice.hx
@@ -4,11 +4,11 @@ import moonchart.backend.FormatData;
 import moonchart.backend.Timing;
 import moonchart.backend.Util;
 import moonchart.formats.BasicFormat;
-import moonchart.formats.fnf.FNFGlobal.BasicFNFPositionCameraEvent;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFCamFocusData;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFEvent;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFNoteType;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFPlayAnimEvent;
+import moonchart.formats.fnf.FNFGlobal.BasicFNFPositionCameraEvent;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFSetCameraBopEvent;
 import moonchart.formats.fnf.FNFGlobal.BasicFNFZoomCameraEvent;
 import moonchart.formats.fnf.FNFGlobal.FNFNoteTypeResolver;
@@ -393,23 +393,22 @@ class FNFVSlice extends BasicJsonFormat<FNFVSliceFormat, FNFVSliceMeta>
 		switch (event.e)
 		{
 			case FNFVSlice.VSLICE_FOCUS_EVENT:
-				if(!(event.v is Int) && (event.v.x != null || event.v.y != null || event.v.duration != null || event.v.ease != null || event.v.easeDir != null)) {
-    				final data:BasicFNFPositionCameraEvent = {
-                        char: event.v.char ?? -1,
-
-        				x: event.v.x,
-        				y: event.v.y,
-
-        				ease: (event.v.ease ?? "CLASSIC") + (event.v.easeDir ?? ""),
-                        duration: event.v.duration ?? 4.0,
-
-                        isOffset: true
-    				}
-                    return {
-                        time: event.t,
-                        name: BasicFNFEvent.POSITION_CAMERA,
-                        data: data
-                    }
+				if (!(event.v is Int)
+					&& (event.v.x != null || event.v.y != null || event.v.duration != null || event.v.ease != null || event.v.easeDir != null))
+				{
+					final data:BasicFNFPositionCameraEvent = {
+						char: event.v.char ?? -1,
+						x: event.v.x,
+						y: event.v.y,
+						ease: (event.v.ease ?? "CLASSIC") + (event.v.easeDir ?? ""),
+						duration: event.v.duration ?? 4.0,
+						isOffset: true
+					}
+					return {
+						time: event.t,
+						name: BasicFNFEvent.POSITION_CAMERA,
+						data: data
+					}
 				}
 			case FNFVSlice.VSLICE_PLAY_ANIMATION_EVENT:
 				final data:BasicFNFPlayAnimEvent = {

--- a/src/moonchart/formats/fnf/FNFVSlice.hx
+++ b/src/moonchart/formats/fnf/FNFVSlice.hx
@@ -391,6 +391,23 @@ class FNFVSlice extends BasicJsonFormat<FNFVSliceFormat, FNFVSliceMeta>
 	{
 		switch (event.e)
 		{
+			case FNFVSlice.VSLICE_FOCUS_EVENT:
+				if(!(event.v is Int) && (event.v.x != null || event.v.y != null || event.v.duration != null || event.v.ease != null || event.v.easeDir != null)) {
+    				final data:BasicFNFPositionCameraEvent = {
+        				x: event.v.x,
+        				y: event.v.y,
+
+        				ease: (event.v.ease ?? "CLASSIC") + (event.v.easeDir ?? ""),
+                        duration: event.v.duration ?? 4.0,
+
+                        isOffset: true
+    				}
+                    return {
+                        time: event.t,
+                        name: BasicFNFEvent.POSITION_CAMERA,
+                        data: data
+                    }
+				}
 			case FNFVSlice.VSLICE_PLAY_ANIMATION_EVENT:
 				final data:BasicFNFPlayAnimEvent = {
 					target: event.v.target,

--- a/src/moonchart/formats/fnf/legacy/FNFPsych.hx
+++ b/src/moonchart/formats/fnf/legacy/FNFPsych.hx
@@ -84,6 +84,10 @@ class FNFPsychBasic<T:PsychJsonFormat> extends FNFLegacyMetaBasic<T, {song:T}>
 			case BasicFNFEvent.PLAY_ANIMATION:
 				var data:BasicFNFPlayAnimEvent = event.data;
 				return makePsychEvent(event.time, "Play Animation", data.anim, data.target);
+
+			case BasicFNFEvent.POSITION_CAMERA:
+			    var data:BasicFNFPositionCameraEvent = event.data;
+				return makePsychEvent(event.time, "Camera Follow Pos", Std.string(data.x), Std.string(data.y));
 		}
 
 		final values:Array<Dynamic> = Util.resolveEventValues(event);
@@ -210,6 +214,22 @@ class FNFPsychBasic<T:PsychJsonFormat> extends FNFLegacyMetaBasic<T, {song:T}>
 					name: BasicFNFEvent.PLAY_ANIMATION,
 					data: data
 				}
+
+			case "Camera Follow Pos":
+                var data:BasicFNFPositionCameraEvent = {
+                    x: Std.parseFloat(event.value1),
+                    y: Std.parseFloat(event.value2),
+
+                    ease: "CLASSIC",
+                    duration: 0, // ease doesn't matter on the CLASSIC ease
+
+                    isOffset: false
+    			}
+                return {
+                    time: time,
+                    name: BasicFNFEvent.POSITION_CAMERA,
+                    data: data
+                }
 		}
 
 		return {

--- a/src/moonchart/formats/fnf/legacy/FNFPsych.hx
+++ b/src/moonchart/formats/fnf/legacy/FNFPsych.hx
@@ -217,6 +217,8 @@ class FNFPsychBasic<T:PsychJsonFormat> extends FNFLegacyMetaBasic<T, {song:T}>
 
 			case "Camera Follow Pos":
                 var data:BasicFNFPositionCameraEvent = {
+                    char: -1,
+
                     x: Std.parseFloat(event.value1),
                     y: Std.parseFloat(event.value2),
 

--- a/src/moonchart/formats/fnf/legacy/FNFPsych.hx
+++ b/src/moonchart/formats/fnf/legacy/FNFPsych.hx
@@ -83,10 +83,16 @@ class FNFPsychBasic<T:PsychJsonFormat> extends FNFLegacyMetaBasic<T, {song:T}>
 		{
 			case BasicFNFEvent.PLAY_ANIMATION:
 				var data:BasicFNFPlayAnimEvent = event.data;
+
+				if (data.anim == "hey")
+				{
+					return makePsychEvent(event.time, "Hey!", data.target, "");
+				}
+
 				return makePsychEvent(event.time, "Play Animation", data.anim, data.target);
 
 			case BasicFNFEvent.POSITION_CAMERA:
-			    var data:BasicFNFPositionCameraEvent = event.data;
+				var data:BasicFNFPositionCameraEvent = event.data;
 				return makePsychEvent(event.time, "Camera Follow Pos", Std.string(data.x), Std.string(data.y));
 		}
 
@@ -216,22 +222,19 @@ class FNFPsychBasic<T:PsychJsonFormat> extends FNFLegacyMetaBasic<T, {song:T}>
 				}
 
 			case "Camera Follow Pos":
-                var data:BasicFNFPositionCameraEvent = {
-                    char: -1,
-
-                    x: Std.parseFloat(event.value1),
-                    y: Std.parseFloat(event.value2),
-
-                    ease: "CLASSIC",
-                    duration: 0, // ease doesn't matter on the CLASSIC ease
-
-                    isOffset: false
-    			}
-                return {
-                    time: time,
-                    name: BasicFNFEvent.POSITION_CAMERA,
-                    data: data
-                }
+				var data:BasicFNFPositionCameraEvent = {
+					char: -1,
+					x: Std.parseFloat(event.value1),
+					y: Std.parseFloat(event.value2),
+					ease: "CLASSIC",
+					duration: 0, // ease doesn't matter on the CLASSIC ease
+					isOffset: false
+				}
+				return {
+					time: time,
+					name: BasicFNFEvent.POSITION_CAMERA,
+					data: data
+				}
 		}
 
 		return {


### PR DESCRIPTION
- FNFVSlice now sets the ease to a proper value when generating basic events instead of setting it to null
- Codename's Camera Zoom and Camera Movement now have eases when resolved from basic events
- Camera Follow Pos (from Psych) and Camera Position (from Codename) now get resolved to a unified Position Camera event, this event also gets resolved to their Psych and Codename specific versions too
- Convert complex V-Slice camera focus events into Position Camera events

NOTE: This PR consists of changes merged from [my personal fork of moonchart](https://github.com/swordcubes-grave-of-shite/moonchart/) via the GitHub website, so there might be some things I forgot